### PR TITLE
Configured stack project for servant dev

### DIFF
--- a/servant-api/servant-api.cabal
+++ b/servant-api/servant-api.cabal
@@ -17,6 +17,12 @@ library
   hs-source-dirs:      src
   exposed-modules:     Lib
   build-depends:       base >= 4.7 && < 5
+                    ,  servant
+                    ,  servant-server
+                    ,  servant-client
+                    ,  servant-foreign
+                    ,  servant-swagger
+                    ,  lackey
   default-language:    Haskell2010
 
 executable servant-api-exe

--- a/servant-api/stack.yaml
+++ b/servant-api/stack.yaml
@@ -39,7 +39,14 @@ packages:
 - '.'
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
-extra-deps: []
+extra-deps:
+  - servant-0.9.0.1
+  - servant-server-0.9.0.1
+  - servant-swagger-1.1.2
+  - lackey-0.4.1
+  - servant-client-0.9.0.1
+  - servant-foreign-0.9.0.1
+  - http-api-data-0.3.2
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
Stackage has an old servant, so stack.yaml is fetching the latest servant. The latest servant introduces ClientM which is far less terrible than ExceptT(ReaderT ) 